### PR TITLE
Alarm triggers when disarming and arming the alarm again

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,4 +16,4 @@ pytest-asyncio = "*"
 black = "==22.12.0"
 
 [packages]
-appdaemon = "==4.0.3"
+appdaemon = "==4.2.1"

--- a/apps/home_alarm/home_alarm.py
+++ b/apps/home_alarm/home_alarm.py
@@ -74,6 +74,10 @@ class HomeAlarm(hass.Hass):
             # Alarm stop action after stop_delay
             self.handle_stop_alarm = await self.run_in(self.stop_alarm, self.stop_delay)
 
+    async def cancel_timer(self, handle):
+        if handle is not None and await self.timer_running(handle):
+            await super().cancel_timer(handle)
+
     async def stop_alarm(self, kwargs=None):
         self.state.set_stopped()
         self.alerts.alarm_stopped()

--- a/apps/home_alarm/home_alarm.py
+++ b/apps/home_alarm/home_alarm.py
@@ -33,6 +33,7 @@ class HomeAlarm(hass.Hass):
         # Sensor that fires alarm
         self.sensor_fired = None
         # Handler functions
+        self.handle_countdown_fired = None
         self.handle_stop_alarm = None
         self.handle_activate_safe_mode = None
 
@@ -63,7 +64,9 @@ class HomeAlarm(hass.Hass):
             and self.safe_mode_active
         ):
             self.state.set_ready_to_fire()
-            self.run_in(self.countdown, self.activation_delay)
+            self.handle_countdown_fired = await self.run_in(
+                self.countdown, self.activation_delay
+            )
 
     async def countdown(self, kwargs):
         safe_mode_state = await self.get_state(self.safe_mode)
@@ -86,6 +89,8 @@ class HomeAlarm(hass.Hass):
             await self.stop_alarm()
 
         self.safe_mode_active = False
+
+        await self.cancel_timer(self.handle_countdown_fired)
         await self.cancel_timer(self.handle_activate_safe_mode)
 
     async def reset_stop_alarm(self):

--- a/apps/home_alarm/home_alarm.py
+++ b/apps/home_alarm/home_alarm.py
@@ -52,16 +52,13 @@ class HomeAlarm(hass.Hass):
     async def door_opened_cb(self, sensor, attribute, old, new, kwargs):
         self.sensor_fired = sensor
         sensor_fired_name = await self.friendly_name(self.sensor_fired)
-        safe_mode_state = await self.get_state(self.safe_mode)
         self.log(f"{sensor_fired_name} activated")
-        self.log(f"`safe_mode` state: {safe_mode_state}")
         self.log(f"`safe_mode_active` state: {self.safe_mode_active}")
         await self.reset_stop_alarm()
         if (
-            safe_mode_state == Generic.ON
+            self.safe_mode_active
             and not self.state.ready_to_fire
             and not self.state.fired
-            and self.safe_mode_active
         ):
             self.state.set_ready_to_fire()
             self.handle_countdown_fired = await self.run_in(
@@ -69,8 +66,7 @@ class HomeAlarm(hass.Hass):
             )
 
     async def countdown(self, kwargs):
-        safe_mode_state = await self.get_state(self.safe_mode)
-        if safe_mode_state == Generic.ON:
+        if self.safe_mode_active:
             self.log("The alarm has been triggered")
             self.state.set_fired()
             # Alarm fired action


### PR DESCRIPTION
### Bug description

The alarm triggers when it is disarmed and armed again within the `activation_delay` window. How to reproduce:
- Activate the alarm and wait `safe_mode_delay` time.
- Open the door (or window, sensor, etc).
- Within the `activation_delay` window, disarm the alarm and arm it back again.

Actual: After doing that, the alarm will be triggered.
Expected: The alarm should not be triggered since it was disarmed and armed again.

### Fix

The problem is that the countdown for the `activation_delay` timer does not have a cancelation policy. This timer should be always canceled when the alarm is disarmed.

### Notes

I have also refactored some code to always use `self.safe_mode_active` rather than the check `await self.get_state(self.safe_mode) == Generic.ON`. It is better to be consistent and use the `self.safe_mode_active` since it is controlled based on `safe_mode_delay` value. This was not causing directly the issue, but it could potentially affect other corner cases. For this reason, it is better to be consistent and use always `self.safe_mode_active`.